### PR TITLE
collection: Don't SHA the Request IP

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,4 @@
 const { Client } = require("pg");
-const crypto = require('crypto')
-const sha256 = value => crypto.createHash('sha256').update(value).digest().toString('base64')
-
 
 // NOTE: any changes to required/optional props will require the database table
 // to be updated first. DO NOT DEPLOY changes to these lists without having
@@ -96,7 +93,7 @@ exports.handler = async (event, context) => {
             })
 
             item.ip = (event.requestContext && event.requestContext.http)
-                ? sha256(event.requestContext.http.sourceIp)
+                ? event.requestContext.http.sourceIp
                 : 'unknown'
 
             optionalProperties.forEach(key => {

--- a/test/app_spec.js
+++ b/test/app_spec.js
@@ -63,7 +63,7 @@ describe('Ping Collector', async function () {
         assert.equal(ping.instanceId, 'test-instance')
         assert.equal(ping['os.type'], 'linux')
         assert.ok(ping.ip)
-        assert.notEqual(ping.ip, '192.168.0.1')
+        assert.equal(ping.ip, '192.168.0.1')
         // Check createdAt is within last 500ms
         assert.ok(Date.now() - ping.created_at.getTime() < 500)
 


### PR DESCRIPTION
Right now the request IP is SHA'ed, which is an inadequate way of protecting against FlowFuse knowing where the request came from. With a small Go program I can iterate through IPs in about 4 minutes and build a rainbow table.

As such, let's not spend the compute and just remove this.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

