### PR TITLE
Add deviceLastSeen and remoteBroker counts to stats

### DIFF
--- a/migrations/20250228-add-device-seen-counts.sql
+++ b/migrations/20250228-add-device-seen-counts.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "pings" ADD COLUMN "platform.counts.devicesByLastSeen.never" integer DEFAULT 0;
+ALTER TABLE "pings" ADD COLUMN "platform.counts.devicesByLastSeen.day" integer DEFAULT 0;
+
+ALTER TABLE "pings" ADD COLUMN "platform.counts.remoteBrokers" integer DEFAULT 0;
+

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,8 @@ const optionalProperties = [
     'platform.counts.projects',
     'platform.counts.projectsByState.suspended',
     'platform.counts.devices',
+    'platform.counts.devicesByLastSeen.never',
+    'platform.counts.devicesByLastSeen.day',
     'platform.counts.projectSnapshots',
     'platform.counts.projectTemplates',
     'platform.counts.projectStacks',
@@ -29,6 +31,7 @@ const optionalProperties = [
     'platform.counts.libraryEntries',
     'platform.counts.sharedLibraryEntries',
     'platform.counts.teamBrokerClients',
+    'platform.counts.remoteBrokers',
     'platform.license.id',
     'platform.license.type'
 ]


### PR DESCRIPTION
Closes https://github.com/FlowFuse/flowfuse/issues/5184
Adds support for:

 - `platform.counts.devicesByLastSeen.never`
 - `platform.counts.devicesByLastSeen.day`
 - `platform.counts.remoteBrokers`

Companion PR for the platform to start reporting this will follow once this is merged and deployed.